### PR TITLE
Add dictionary loader, encode and decode VSA

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -3,6 +3,7 @@ package radius
 // Attribute is a RADIUS attribute, which is part of a RADIUS packet.
 type Attribute struct {
 	Type  byte
+	VendorID uint32
 	Value interface{}
 }
 

--- a/client.go
+++ b/client.go
@@ -91,7 +91,7 @@ func (c *Client) Exchange(packet *Packet, addr string) (*Packet, error) {
 			conn.Close()
 			return nil, err
 		}
-		received, err := Parse(incoming[:n], packet.Secret, packet.Dictionary)
+		received, err := Parse(incoming[:n], packet.Secret, packet.Dictionary, packet.DictionaryVendor)
 		if err == nil && received.IsAuthentic(packet) {
 			conn.Close()
 			return received, nil

--- a/dictionary_parser.go
+++ b/dictionary_parser.go
@@ -1,0 +1,118 @@
+package radius
+
+import (
+	"os"
+	"bufio"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type dictionaryAttribute struct {
+	Name   string
+	Format string
+}
+
+type dictionaryVendor struct {
+	ID   uint32
+	Name string
+	Attributes [256]*dictionaryAttribute
+}
+
+type dictionaryRegexp struct {
+	reVendor       *regexp.Regexp
+	reAttribute    *regexp.Regexp
+	namesVendor    []string
+	namesAttribute []string
+}
+
+type DictionaryParser struct {
+	Vendors      map[uint32]*dictionaryVendor
+	parserRegexp *dictionaryRegexp
+}
+
+func (dr *dictionaryRegexp) init() {
+	patternVendor := `VENDOR\s*(?P<VendorName>[[:alnum:]]*)\s*` +
+	                 `(?P<VendorID>[[:digit:]]*)`
+	patternAttr   := `ATTRIBUTE\s*(?P<AttrName>[a-zA-Z0-9\-\_]*)\s*` +
+	                 `(?P<AttrID>[[:digit:]]*)\s*` +
+	                 `(?P<AttrFormat>[[:alnum:]]*\s*)`
+
+	dr.reVendor = regexp.MustCompile(patternVendor)
+	dr.reAttribute = regexp.MustCompile(patternAttr)
+	dr.namesVendor = dr.reVendor.SubexpNames()
+	dr.namesAttribute = dr.reAttribute.SubexpNames()
+}
+
+func (dr *dictionaryRegexp) lineParse(line string) (rtype int, result map[string]string) {
+	var names []string
+	var r []string
+
+	rtype = 0
+
+	if dr.reAttribute.MatchString(line) {
+		r = dr.reAttribute.FindAllStringSubmatch(line, -1)[0]
+		rtype = 2
+		names = dr.namesAttribute
+	} else if dr.reVendor.MatchString(line) {
+		r = dr.reVendor.FindAllStringSubmatch(line, -1)[0]
+		rtype = 1
+		names = dr.namesVendor
+	}
+
+	if rtype > 0 {
+		result = map[string]string{}
+		for i, val := range r {
+			result[names[i]] = val
+		}
+	}
+
+	return
+}
+
+func (dp *DictionaryParser) Parse(f string) {
+	if dp.parserRegexp == nil {
+		dp.parserRegexp = &dictionaryRegexp{}
+		dp.parserRegexp.init()
+	}
+
+	if dp.Vendors == nil {
+		dp.Vendors = make(map[uint32]*dictionaryVendor)
+	}
+
+	handle, _ := os.Open(f)
+	defer handle.Close()
+
+	vid := uint32(0)
+
+	scanner := bufio.NewScanner(handle)
+	for scanner.Scan() {
+		rtype, result := dp.parserRegexp.lineParse(scanner.Text())
+		switch rtype {
+			case 1:
+			cvid, err := strconv.Atoi(result["VendorID"])
+			if err == nil {
+				vid = uint32(cvid)
+				if dp.Vendors[vid] == nil {
+					dp.Vendors[vid] = &dictionaryVendor{}
+				}
+
+				dp.Vendors[vid].ID = vid
+			}
+			case 2:
+			caid, err := strconv.Atoi(result["AttrID"])
+			if err == nil && vid != 0 {
+				aid := byte(caid)
+
+				if dp.Vendors[vid].Attributes[aid] == nil {
+					dp.Vendors[vid].Attributes[aid] = &dictionaryAttribute{}
+				}
+
+				dp.Vendors[vid].Attributes[aid].Name =
+					strings.TrimSpace(result["AttrName"])
+				dp.Vendors[vid].Attributes[aid].Format =
+					strings.TrimSpace(result["AttrFormat"])
+			}
+		}
+	}
+}

--- a/dictionary_vendor.go
+++ b/dictionary_vendor.go
@@ -1,0 +1,225 @@
+package radius
+
+import (
+	"errors"
+	"sync"
+	"bytes"
+)
+
+// Vendor is the Vendor-Specific dictionary.
+var Vendor  *DictionaryVendor
+
+type dictVendorEntry struct {
+	Type     byte
+	VendorID uint32
+	Name     string
+	Codec    AttributeCodec
+}
+
+type vendorEntry struct {
+	VendorID         uint32
+	Name             string
+	attributesByType [256]*dictVendorEntry
+}
+
+// Dictionary stores mappings between vendor-attribute names and types and
+// AttributeCodecs.
+type DictionaryVendor struct {
+	mu               sync.RWMutex
+	vendorID         map[uint32]*vendorEntry
+	attributesByName map[string]*dictVendorEntry
+}
+
+// Register registers the AttributeCodec for the given vendor-attribute name and type.
+func (d *DictionaryVendor) Register(vendorID uint32, name string, t byte, codec AttributeCodec) error {
+	d.mu.Lock()
+	entry := &dictVendorEntry{
+		Type:  t,
+		VendorID: vendorID,
+		Name:  name,
+		Codec: codec,
+	}
+
+	if d.vendorID == nil {
+		d.vendorID = make(map[uint32]*vendorEntry)
+	}
+
+	if d.vendorID[vendorID] == nil {
+		vEntry := &vendorEntry{
+			VendorID: vendorID,
+		}
+
+		d.vendorID[vendorID] = vEntry
+	}
+	d.vendorID[vendorID].attributesByType[t] = entry
+
+	if d.attributesByName == nil {
+		d.attributesByName = make(map[string]*dictVendorEntry)
+	}
+	d.attributesByName[name] = entry
+	d.mu.Unlock()
+	return nil
+}
+
+// MustRegister is a helper for Register that panics if it returns an error.
+func (d *DictionaryVendor) MustRegister(vendorID uint32, name string, t byte, codec AttributeCodec) {
+	if err := d.Register(vendorID, name, t, codec); err != nil {
+		panic(err)
+	}
+}
+
+func (d *DictionaryVendor) get(name string) (vendorID uint32, t byte, codec AttributeCodec, ok bool) {
+	d.mu.RLock()
+	entry := d.attributesByName[name]
+	d.mu.RUnlock()
+	if entry == nil {
+		return
+	}
+	t = entry.Type
+	vendorID = entry.VendorID
+	codec = entry.Codec
+	ok = true
+	return
+}
+
+// Attr returns a new *Attribute whose type is registered under the given
+// name.
+//
+// If name is not registered, nil and an error is returned.
+func (d *DictionaryVendor) Attr(name string, value interface{}) (*Attribute, error) {
+	vendorID, t, _, ok := d.get(name)
+	if !ok {
+		return nil, errors.New("radius: attribute name not registered")
+	}
+
+	codec := d.Codec(vendorID, t)
+	wire, err := codec.Encode(nil, value)
+	if err != nil {
+		return nil, err
+	}
+
+	var bufferAttrs bytes.Buffer
+	bufferAttrs.WriteByte(t)
+	bufferAttrs.WriteByte(byte(len(wire) + 2))
+	bufferAttrs.Write(wire)
+
+	encodedValue := VendorSpecific {
+		VendorID: vendorID,
+		Data: bufferAttrs.Bytes(),
+	}
+
+	return &Attribute{
+		Type: 26,
+		VendorID: vendorID,
+		Value: encodedValue,
+	}, nil
+}
+
+// MustAttr is a helper for Attr that panics if Attr were to return an error.
+func (d *DictionaryVendor) MustAttr(name string, value interface{}) *Attribute {
+	attr, err := d.Attr(name, value)
+	if err != nil {
+		panic(err)
+	}
+	return attr
+}
+
+// Name returns the registered name for the given attribute type. ok is false
+// if the given type is not registered.
+func (d *DictionaryVendor) Name(vendorID uint32, t byte) (name string, ok bool) {
+	d.mu.RLock()
+	var entry *dictVendorEntry
+
+	if d.vendorID[vendorID] != nil &&
+	   d.vendorID[vendorID].attributesByType[t] != nil {
+		entry = d.vendorID[vendorID].attributesByType[t]
+	}
+	d.mu.RUnlock()
+	if entry == nil {
+		return
+	}
+	name = entry.Name
+	ok = true
+	return
+}
+
+// Type returns the registered type for the given attribute name. ok is false
+// if the given name is not registered.
+func (d *DictionaryVendor) Type(name string) (t byte, ok bool) {
+	d.mu.RLock()
+	entry := d.attributesByName[name]
+	d.mu.RUnlock()
+	if entry == nil {
+		return
+	}
+	t = entry.Type
+	ok = true
+	return
+}
+
+// Codec returns the AttributeCodec for the given registered type. nil is
+// returned if the given type is not registered.
+func (d *DictionaryVendor) Codec(vendorID uint32, t byte) AttributeCodec {
+	d.mu.RLock()
+	var entry *dictVendorEntry
+
+	if d.vendorID[vendorID] != nil &&
+	   d.vendorID[vendorID].attributesByType[t] != nil {
+		entry = d.vendorID[vendorID].attributesByType[t]
+	}
+	d.mu.RUnlock()
+	if entry == nil {
+		return AttributeUnknown
+	}
+	return entry.Codec
+}
+
+// Name returns the registered attribute for the given attribute type.
+func (d *DictionaryVendor) AttrByType(vendorID uint32, t byte) (attribute *dictVendorEntry) {
+	d.mu.RLock()
+	var entry *dictVendorEntry
+
+	if d.vendorID[vendorID] != nil &&
+	   d.vendorID[vendorID].attributesByType[t] != nil {
+		entry = d.vendorID[vendorID].attributesByType[t]
+	}
+	d.mu.RUnlock()
+	if entry == nil {
+		return
+	}
+	attribute = entry
+	return
+}
+
+func (d *DictionaryVendor) SubAttributes(vendorID uint32, data []byte) (attributes []*Attribute) {
+	dataLength := len(data)
+	if dataLength < 2 || dataLength > 249 {
+		return
+	}
+
+	n := byte(0)
+	for (n+2) < byte(dataLength) {
+		aid := data[n:n+1][0]
+		length := data[n+1:n+2][0]
+
+		if entry := d.AttrByType(vendorID, aid); entry != nil {
+			val := make([]byte, length - 2)
+			copy(val, data[n+2:length])
+			decoded, err := entry.Codec.Decode(nil, val)
+
+			if err == nil {
+				attr := &Attribute {
+					Type: aid,
+					VendorID: vendorID,
+					Value: decoded,
+				}
+
+				attributes = append(attributes, attr)
+			}
+		}
+
+		n = n + length
+	}
+
+	return
+}

--- a/server.go
+++ b/server.go
@@ -70,6 +70,7 @@ func (r *responseWriter) accessRespond(code Code, attributes ...*Attribute) erro
 		Secret: r.packet.Secret,
 
 		Dictionary: r.packet.Dictionary,
+		DictionaryVendor: r.packet.DictionaryVendor,
 
 		Attributes: attributes,
 	}
@@ -117,6 +118,7 @@ type Server struct {
 
 	// Dictionary used when decoding incoming packets.
 	Dictionary *Dictionary
+	DictionaryVendor *DictionaryVendor
 
 	// The packet handler that handles incoming, valid packets.
 	Handler Handler
@@ -148,7 +150,7 @@ func (s *Server) Serve(pc net.PacketConn) error {
 			continue
 		}
 
-		packet, err := Parse(buff[:n], s.Secret, s.Dictionary)
+		packet, err := Parse(buff[:n], s.Secret, s.Dictionary, s.DictionaryVendor)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
- Add FreeRADIUS's dictionary files parser.

dictionary.huawei:
VENDOR        Huawei           2011

BEGIN-VENDOR  Huawei
ATTRIBUTE     Huawei-Input-Burst-Size      1       integer
...
ATTRIBUTE     Huawei-Gateway               73      ipaddr
...
ATTRIBUTE     Huawei-L2TP-Terminate-Cause  89      octets
...
ATTRIBUTE     Huawei-Version               254     string
...
END-VENDOR  Huawei

The parser is only parsing the VENDOR and ATTRIBUTE fields but
leaving the VALUE field for the future implementation.
- Load dictionary files from /usr/local/share/go-radius (hardcoded) into
  separated Vendor dictionary.
- Encode and Decode VSA
  Packet encoder/decoder will determine the attributes which are the VSA
  and encode/decode as type 26 (Vendor-Specific).
- Add TestVSA to verify the functionality of VSA implementation
