### PR TITLE
generate StringLookups for radius.Type

### DIFF
--- a/dictionarygen/attributes.go
+++ b/dictionarygen/attributes.go
@@ -455,3 +455,16 @@ func (g *Generator) genAttributeInteger(w io.Writer, attr *dictionary.Attribute,
 	}
 	p(w, `}`)
 }
+
+func (g *Generator) genAttributeStringLookups(w io.Writer, attrs []*dictionary.Attribute, postfix, attributeType string) {
+	p(w, `func StringLookup(a `, attributeType, `) string {`)
+	p(w, `	switch a {`)
+	for _, attr := range attrs {
+		id := identifier(attr.Name)
+		p(w, `			case `, id, postfix, `: return "`, id, `"`)
+	}
+	p(w, `	}`)
+	p(w)
+	p(w, `	return ""`)
+	p(w, `}`)
+}

--- a/dictionarygen/generator.go
+++ b/dictionarygen/generator.go
@@ -214,6 +214,7 @@ func (g *Generator) Generate(dict *dictionary.Dictionary) ([]byte, error) {
 			p(&w, `	`, identifier(attr.Name), `_Type radius.Type = `, attr.OID)
 		}
 		p(&w, `)`)
+		g.genAttributeStringLookups(&w, attrs, "_Type", "radius.Type")
 	}
 
 	if len(vendors) > 0 {


### PR DESCRIPTION
This would be the generation pattern that would probably support debug type -> string resolution for #13 

I tried to make the `StringLookup` generic enough that the name (`StringLookup`) could be changed/reused for other locations in the future.

I (will but haven't) regenerated the dictionaries because I wanted insight if this was acceptable before doing that.

I'm quick to know that the name `StringLookup` itself is probably bad but I wasn't sure if there was a preference (especially if, in the future, something like Service Type should also have a lookup) and/or whether this should be more explicit about being for debug?

anyway I did test against rfc2865, sorry for dumping the diff but, like I said, I didn't want to do the generations without some form of knowledge that it was worthwhile:

```
diff --git a/rfc2865/generated.go b/rfc2865/generated.go
index 4d8d4a0..6bc9349 100644
--- a/rfc2865/generated.go
+++ b/rfc2865/generated.go
@@ -53,6 +53,95 @@ const (
 	LoginLATPort_Type           radius.Type = 63
 )
 
+func StringLookup(a radius.Type) string {
+	switch a {
+	case UserName_Type:
+		return "UserName"
+	case UserPassword_Type:
+		return "UserPassword"
+	case CHAPPassword_Type:
+		return "CHAPPassword"
+	case NASIPAddress_Type:
+		return "NASIPAddress"
+	case NASPort_Type:
+		return "NASPort"
+	case ServiceType_Type:
+		return "ServiceType"
+	case FramedProtocol_Type:
+		return "FramedProtocol"
+	case FramedIPAddress_Type:
+		return "FramedIPAddress"
+	case FramedIPNetmask_Type:
+		return "FramedIPNetmask"
+	case FramedRouting_Type:
+		return "FramedRouting"
+	case FilterID_Type:
+		return "FilterID"
+	case FramedMTU_Type:
+		return "FramedMTU"
+	case FramedCompression_Type:
+		return "FramedCompression"
+	case LoginIPHost_Type:
+		return "LoginIPHost"
+	case LoginService_Type:
+		return "LoginService"
+	case LoginTCPPort_Type:
+		return "LoginTCPPort"
+	case ReplyMessage_Type:
+		return "ReplyMessage"
+	case CallbackNumber_Type:
+		return "CallbackNumber"
+	case CallbackID_Type:
+		return "CallbackID"
+	case FramedRoute_Type:
+		return "FramedRoute"
+	case FramedIPXNetwork_Type:
+		return "FramedIPXNetwork"
+	case State_Type:
+		return "State"
+	case Class_Type:
+		return "Class"
+	case VendorSpecific_Type:
+		return "VendorSpecific"
+	case SessionTimeout_Type:
+		return "SessionTimeout"
+	case IdleTimeout_Type:
+		return "IdleTimeout"
+	case TerminationAction_Type:
+		return "TerminationAction"
+	case CalledStationID_Type:
+		return "CalledStationID"
+	case CallingStationID_Type:
+		return "CallingStationID"
+	case NASIdentifier_Type:
+		return "NASIdentifier"
+	case ProxyState_Type:
+		return "ProxyState"
+	case LoginLATService_Type:
+		return "LoginLATService"
+	case LoginLATNode_Type:
+		return "LoginLATNode"
+	case LoginLATGroup_Type:
+		return "LoginLATGroup"
+	case FramedAppleTalkLink_Type:
+		return "FramedAppleTalkLink"
+	case FramedAppleTalkNetwork_Type:
+		return "FramedAppleTalkNetwork"
+	case FramedAppleTalkZone_Type:
+		return "FramedAppleTalkZone"
+	case CHAPChallenge_Type:
+		return "CHAPChallenge"
+	case NASPortType_Type:
+		return "NASPortType"
+	case PortLimit_Type:
+		return "PortLimit"
+	case LoginLATPort_Type:
+		return "LoginLATPort"
+	}
+
+	return ""
+}
+
 func UserName_Add(p *radius.Packet, value []byte) (err error) {
 	var a radius.Attribute
 	a, err = radius.NewBytes(value)
```