### PR TITLE
add Authenticator to requestKey

### DIFF
--- a/server-packet.go
+++ b/server-packet.go
@@ -95,8 +95,9 @@ func (s *PacketServer) Serve(conn net.PacketConn) error {
 	s.mu.Unlock()
 
 	type requestKey struct {
-		IP         string
-		Identifier byte
+		IP            string
+		Identifier    byte
+		Authenticator [16]byte
 	}
 
 	var (
@@ -151,8 +152,9 @@ func (s *PacketServer) Serve(conn net.PacketConn) error {
 			}
 
 			key := requestKey{
-				IP:         remoteAddr.String(),
-				Identifier: packet.Identifier,
+				IP:            remoteAddr.String(),
+				Identifier:    packet.Identifier,
+				Authenticator: packet.Authenticator,
 			}
 			requestsLock.Lock()
 			if _, ok := requests[key]; ok {


### PR DESCRIPTION
RADIUS protocol only uses one byte `Identifier` to check repeat packets. But when processing mass concurrency requests, the identifier from the same remote address also maybe duplicate. The duplicated identifier indicates the packets are same and will be dropped. But actually, in this situation, they are different packets and should not be dropped.
So I added `Authenticator` into the `requestKey` to avoid this problem. `Authenticator` has enough length of 16 bytes. According to the protocol, `Authenticator` should be random, or generated from the packet contents with secret. Some different packets hardly have the same `Authenticator`.