### PR TITLE
Handle declared length vs. actual length mismatch according to RFC2865

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -48,11 +48,11 @@ func Parse(b, secret []byte) (*Packet, error) {
 	}
 
 	length := int(binary.BigEndian.Uint16(b[2:4]))
-	if length < 20 || length > MaxPacketLength || len(b) != length {
+	if length < 20 || length > MaxPacketLength || len(b) < length {
 		return nil, errors.New("radius: invalid packet length")
 	}
 
-	attrs, err := ParseAttributes(b[20:])
+	attrs, err := ParseAttributes(b[20:length])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Radius RFC2865 Section 3, states how to handle mismatch between the value in the length field and the actual packet size:
   Length

      The Length field is two octets.  It indicates the length of the
      packet including the Code, Identifier, Length, Authenticator and
      Attribute fields.  Octets outside the range of the Length field
      MUST be treated as padding and ignored on reception.  If the
      packet is shorter than the Length field indicates, it MUST be
      silently discarded.  The minimum length is 20 and maximum length
      is 4096.
Thus, according to this the case where the packet length is greater than the length field value, shouldn't be discarded as the current implementation, but trunced to fit the declared length.