### PR TITLE
[radius][packet-server] Add logger to PacketServer

### DIFF
--- a/cmd/radserver/main.go
+++ b/cmd/radserver/main.go
@@ -82,6 +82,7 @@ func main() {
 	server := radius.PacketServer{
 		Handler:      radius.HandlerFunc(handler),
 		SecretSource: radius.StaticSecretSource([]byte(*secret)),
+		ErrLog:       log.New(os.Stderr, "", log.Ltime|log.Lshortfile|log.Ldate),
 	}
 
 	if err := server.ListenAndServe(); err != nil {


### PR DESCRIPTION
Adding a simple logger to PacketServer. Implementation mirrors [net/http ](https://golang.org/src/net/http/server.go?s=63137:63189#L3085) package internals. If a caller doesn't set a logger on the PacketServer struct, the 'log' package default logger will be used. The log package default logger just dumps to stdout.