### PR TITLE
Add SecretSourceWithBytes interface type

### DIFF
--- a/server.go
+++ b/server.go
@@ -87,3 +87,15 @@ type staticSecretSource struct {
 func (s *staticSecretSource) RADIUSSecret(ctx context.Context, remoteAddr net.Addr) ([]byte, error) {
 	return s.secret, nil
 }
+
+// SecretSourceWithBytes supplies RADIUS servers with the secret that should be used for
+// authorizing and decrypting packets. This interface has access to the received radius packet
+// in wire format. This provides the alternative of using packet information
+// to determine a secret when relying on RemoteAddr is not feasible.
+//
+// ctx is canceled if the server's Shutdown method is called.
+//
+// Returning an empty secret will discard the incoming packet.
+type SecretSourceWithBytes interface {
+	RADIUSSecretWithBytes(ctx context.Context, buff []byte) ([]byte, error)
+}


### PR DESCRIPTION
This PR is in response to [Issue #82 ](https://github.com/layeh/radius/issues/82). 

Summary:
These changes add another method of determining a secret to use for an incoming radius packet, without modifying the existing behavior of SecretSource interface. Relying on Remote Address is sadly really painful to do in my current employer's environment. It is much easier for us to rely on NAS-Identifier information, or possibly other attributes.

My goal with the first attempt at this was to not cause any breaking changes to the existing SecretSource interface. I'm open to any suggestion on how to do this differently. It is probably a bit cleaner to just extend the existing SecretSource method to also accept the wire format bytes, but I wasn't sure how you would feel about a breaking change like that.
