### PR TITLE
Tolerate non-zero bits beyond the prefix in IPv6Prefix (fixes #119)

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -474,14 +474,14 @@ func IPv6Prefix(a Attribute) (*net.IPNet, error) {
 	ip := make(net.IP, net.IPv6len)
 	copy(ip, a[2:])
 
-	bit := uint(prefixLength % 8)
-	for octet := prefixLength / 8; octet < len(ip); octet++ {
-		for ; bit < 8; bit++ {
-			if ip[octet]&(1<<(7-bit)) != 0 {
-				return nil, errors.New("invalid prefix data")
-			}
-		}
-		bit = 0
+	// Clear any bits beyond the prefix length. RFC 3162 requires these bits to
+	// be zero, but some equipment leaves them set; tolerate that here instead
+	// of rejecting the attribute.
+	if bit := uint(prefixLength % 8); bit != 0 {
+		ip[prefixLength/8] &^= 0xff >> bit
+	}
+	for octet := (prefixLength + 7) / 8; octet < len(ip); octet++ {
+		ip[octet] = 0
 	}
 
 	return &net.IPNet{

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -143,6 +143,39 @@ func TestIPv6Prefix_issue118(t *testing.T) {
 	}
 }
 
+func TestIPv6Prefix_issue119(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Attr     []byte
+		Expected string
+	}{
+		{
+			// /64 prefix sent with the host bits (::1) still set.
+			Name:     "host bits set",
+			Attr:     []byte{0x00, 0x40, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			Expected: "2001:db8::/64",
+		},
+		{
+			// /47 prefix with a non-zero bit beyond the prefix length.
+			Name:     "non-octet boundary with trailing bit",
+			Attr:     []byte{0x00, 0x2f, 0x20, 0x01, 0x15, 0x30, 0x10, 0x0f},
+			Expected: "2001:1530:100e::/47",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			ipNet, err := IPv6Prefix(tt.Attr)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got := ipNet.String(); got != tt.Expected {
+				t.Fatalf("got %s, expected %s", got, tt.Expected)
+			}
+		})
+	}
+}
+
 func ipNetEquals(a, b *net.IPNet) bool {
 	if a == nil && b == nil {
 		return true


### PR DESCRIPTION
## Summary

Fixes #119 (follow-up to #118). `IPv6Prefix` rejected any `Framed-IPv6-Prefix` / `Delegated-IPv6-Prefix` attribute whose bits beyond the `Prefix-Length` were non-zero, returning `invalid prefix data`.

The validation loop added in 1006025 (the #118 fix) is too strict. Real-world equipment frequently leaves the padding bits set — for example:

- a `/64` sent with the host identifier still present (`2001:db8::1/64`), or
- a non-octet-aligned prefix carrying a trailing non-zero bit (`/47` with bit 47 set).

Per RFC 3162 those bits *should* be zero, but rejecting otherwise-valid prefixes breaks decoding of packets from common gear.

## Fix

Clear the bits beyond the prefix length instead of erroring:

- mask the trailing bits of the partial byte (`ip[prefixLength/8] &^= 0xff >> (prefixLength%8)`), and
- zero every whole byte after it.

This restores the lenient behaviour that predated #118 while keeping that fix's tolerance for omitted trailing zero bytes. The approach matches the suggestion in review comment [r134862652](https://github.com/layeh/radius/commit/1006025d24f8fdd5b5ee8b3c15a714e6b24baaab#r134862652) on the original commit.

## Tests

`TestIPv6Prefix_issue119` covers both the host-bits-set `/64` case and the non-octet `/47` case; both fail on the previous code with `invalid prefix data` and pass now. Existing `TestIPv6Prefix` and `TestIPv6Prefix_issue118` continue to pass, and `go test ./...` / `go vet ./...` are clean.

Thanks to @dav-komarek for the report and reproduction.
